### PR TITLE
Return signed msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We recommend using the npmjs package in order to receive updates/fixes.
 | Operation       | Response                                                                         | Command                                                                                                         | Notes                                       |
 | --------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
 | signTransaction | { signature: string }                                                            | txType + senderAccount + senderAddress + receiverAddress + amount + fee + nonce + validUntil + memo + networkId | Signs a Mina transaction                    |
-| signMessage     | { field: string, scalar: string, raw_signature: string } | account + networkId + message                                                                                   | Signs a message using the specified account |
+| signMessage     | { field: string, scalar: string, raw_signature: string, signed_message: string } | account + networkId + message                                                                                   | Signs a message using the specified account |
 
 ### Transaction Types
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zondax/ledger-mina-js",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Node API for the Mina App (Ledger Nano S, S+, X, Stax and Flex)",
   "keywords": [
     "Zondax",

--- a/src/app.ts
+++ b/src/app.ts
@@ -63,6 +63,7 @@ interface SignMessageResponse extends BaseLedgerResponse {
   field: string | null;
   scalar: string | null;
   raw_signature?: string | null;
+  signed_message?: string | null;
 }
 
 export class MinaApp extends BaseApp {
@@ -305,6 +306,7 @@ export class MinaApp extends BaseApp {
         field: null,
         scalar: null,
         raw_signature: null,
+        signed_message: null,
         returnCode: "-6",
         message: "Message is empty",
       };
@@ -314,6 +316,7 @@ export class MinaApp extends BaseApp {
         field: null,
         scalar: null,
         raw_signature: null,
+        signed_message: null,
         returnCode: "-7",
         message: "Message too long",
       };
@@ -347,15 +350,37 @@ export class MinaApp extends BaseApp {
 
       const response = processResponse(responseBuffer);
 
+      // Validate minimum buffer length (64 bytes for signature + 1 byte for message length)
+      if (response.length() < 65) {
+        throw new Error("Response buffer too short");
+      }
+
+      // First read the signature (64 bytes)
       const signature = response.readBytes(64).toString("hex");
       const sigLength = signature.length;
       const field_extracted = signature.substring(0, sigLength / 2);
       const scalar_extracted = signature.substring(sigLength / 2, sigLength);
 
+      // Then read the message length (1 byte)
+      const messageLength = response.readBytes(1).readUInt8();
+
+      // Validate remaining buffer length against message length
+      if (response.length() < messageLength) {
+        throw new Error(
+          `Response buffer too short for message: expected ${messageLength} bytes but only ${response.length()} remaining`,
+        );
+      }
+
+      // Finally read the message
+      const returnedMessage = response
+        .readBytes(messageLength)
+        .toString("utf8");
+
       return {
         field: BigInt("0x" + field_extracted).toString(),
         scalar: BigInt("0x" + scalar_extracted).toString(),
         raw_signature: signature,
+        signed_message: returnedMessage,
         returnCode: "9000",
       };
     } catch (e) {
@@ -364,6 +389,7 @@ export class MinaApp extends BaseApp {
         field: null,
         scalar: null,
         raw_signature: null,
+        signed_message: null,
         returnCode: respError.returnCode.toString(),
         message: respError.errorMessage,
       };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The response for message signing now includes the original signed message along with the signature details.

* **Documentation**
  * Updated documentation to reflect the addition of the `signed_message` field in the sign message operation response.

* **Chores**
  * Updated the package version to 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->