### PR TITLE
Allow amount 0 on transactions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -215,7 +215,6 @@ export class MinaApp extends BaseApp {
       isNaN(senderAccount) ||
       !senderAddress ||
       !receiverAddress ||
-      (!amount && txType === 0) /* PAYMENT */ ||
       !fee ||
       !Number.isInteger(amount) ||
       !Number.isInteger(fee) ||


### PR DESCRIPTION
As mentioned in [here](https://github.com/o1-labs/mina-rust/issues/1440#issuecomment-3332532553), the Mina team needs to allow transactions with an amount of `0` for OCV.